### PR TITLE
Updated Scale Issues, added in zoom function and added auto scale toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,9 +211,17 @@
                             <label>Node Removal Timeout: <span id="removalTimeoutValue">30</span>s</label>
                             <input type="range" id="removalTimeoutSlider" min="10" max="180" value="30" step="10">
                         </div>
+                        <div class="input-group" style="display: flex; align-items: center; gap: 8px;">
+                            <label for="autoScaleToggle" style="margin: 0;">Auto Scale</label>
+                            <input type="checkbox" id="autoScaleToggle" checked>
+                        </div>
                         <div class="input-group">
                             <label>Display Scale: <span id="scaleValue">120</span>px/m</label>
-                            <input type="range" id="scaleSlider" min="50" max="250" value="120" step="10">
+                            <input type="range" id="scaleSlider" min="10" max="500" value="120" step="5">
+                        </div>
+                        <div class="input-group zoom-controls">
+                            <button class="btn" id="zoomOut">- Zoom Out</button>
+                            <button class="btn" id="zoomIn">+ Zoom In</button>
                         </div>
                     </div>
                 </div>

--- a/js/physics.js
+++ b/js/physics.js
@@ -29,6 +29,7 @@ class SpringMassSystem {
         // Auto-scaling parameters - highly responsive with better centering
         this.targetScreenUsage = 0.7;   // Target 70% usage for better centering
         this.scaleAdjustmentRate = 0.1; // Ultra-fast scale adjustments
+        this.autoScaleEnabled = true; // Allow toggling auto/manual scaling
     }
     
     initializeNode(node, canvasWidth, canvasHeight) {
@@ -126,8 +127,13 @@ class SpringMassSystem {
     }
     
     applyBoundaryForces(nodes, canvasWidth, canvasHeight) {
-        // Keep masses within the usable screen area (70% of total) - stronger containment
-        const margin = Math.min(canvasWidth, canvasHeight) * 0.15; // Increased margin for better centering
+        // Use a smaller margin when zoomed out (distanceScale < 40)
+        let margin;
+        if (this.distanceScale < 40) {
+            margin = Math.min(canvasWidth, canvasHeight) * 0.05;
+        } else {
+            margin = Math.min(canvasWidth, canvasHeight) * 0.15;
+        }
         const minX = margin;
         const maxX = canvasWidth - margin;
         const minY = margin;
@@ -209,7 +215,8 @@ class SpringMassSystem {
                 // More aggressive scale adjustment for faster response
                 const adjustment = (sizeRatio - 1) * this.scaleAdjustmentRate;
                 this.distanceScale *= (1 + adjustment);
-                this.distanceScale = Math.max(50, Math.min(this.distanceScale, 300));
+                // Use the same min/max as the UI slider
+                this.distanceScale = Math.max(10, Math.min(this.distanceScale, 500));
             }
         }
     }
@@ -251,8 +258,10 @@ class SpringMassSystem {
         this.applyBoundaryForces(nodes, canvasWidth, canvasHeight);
         this.applyCenteringForce(nodes, canvasWidth, canvasHeight);
         
-        // Auto-scale to maintain 80% screen usage - faster adjustments
-        this.autoScale(nodes, canvasWidth, canvasHeight);
+        // Auto-scale to maintain 80% screen usage - only if enabled
+        if (this.autoScaleEnabled) {
+            this.autoScale(nodes, canvasWidth, canvasHeight);
+        }
         
         // Integrate equations of motion - less damping, lighter mass = faster movement
         this.integrateMotion(nodes);

--- a/js/visualizer/visualizer-ui.js
+++ b/js/visualizer/visualizer-ui.js
@@ -87,6 +87,41 @@ class VisualizerUIManager {
             if (valueElement) valueElement.textContent = e.target.value;
         }, '(Scale)');
 
+        // Zoom In/Out button controls
+        const scaleSlider = document.getElementById('scaleSlider');
+        const scaleValue = document.getElementById('scaleValue');
+        const zoomInBtn = document.getElementById('zoomIn');
+        const zoomOutBtn = document.getElementById('zoomOut');
+        if (zoomInBtn && scaleSlider) {
+            zoomInBtn.addEventListener('click', () => {
+                let newValue = Math.min(parseInt(scaleSlider.value) + 10, parseInt(scaleSlider.max));
+                scaleSlider.value = newValue;
+                if (scaleValue) scaleValue.textContent = newValue;
+                this.visualizer.physicsManager.updateScale(newValue);
+            });
+        }
+        if (zoomOutBtn && scaleSlider) {
+            zoomOutBtn.addEventListener('click', () => {
+                let newValue = Math.max(parseInt(scaleSlider.value) - 10, parseInt(scaleSlider.min));
+                scaleSlider.value = newValue;
+                if (scaleValue) scaleValue.textContent = newValue;
+                this.visualizer.physicsManager.updateScale(newValue);
+            });
+        }
+
+        // Mouse wheel zoom support on canvas
+        if (scaleSlider && this.visualizer.canvas) {
+            this.visualizer.canvas.addEventListener('wheel', (e) => {
+                e.preventDefault();
+                let delta = e.deltaY < 0 ? 10 : -10;
+                let newValue = parseInt(scaleSlider.value) + delta;
+                newValue = Math.max(parseInt(scaleSlider.min), Math.min(parseInt(scaleSlider.max), newValue));
+                scaleSlider.value = newValue;
+                if (scaleValue) scaleValue.textContent = newValue;
+                this.visualizer.physicsManager.updateScale(newValue);
+            }, { passive: false });
+        }
+
         safeAddEventListener('enablePhysics', 'change', (e) => {
             this.visualizer.togglePhysics(e.target.checked);
         }, '(Enable Physics)');
@@ -136,6 +171,16 @@ class VisualizerUIManager {
             if (valueElement) valueElement.textContent = rateLimitSeconds;
             this.visualizer.mqttManager?.publishRateLimitCommand(rateLimitSeconds);
         }, '(Rate Limit)');
+
+        // Add event listener for auto scale toggle
+        const autoScaleCheckbox = document.getElementById('autoScaleToggle');
+        if (autoScaleCheckbox) {
+            autoScaleCheckbox.addEventListener('change', (e) => {
+                const enabled = e.target.checked;
+                this.visualizer.physics.autoScaleEnabled = enabled;
+                this.visualizer.loggingManager?.logInfo(`Auto Scale ${enabled ? 'enabled' : 'disabled'}`);
+            });
+        }
 
         // Button controls with touch feedback
         this.setupButtonControls();


### PR DESCRIPTION
There was display scale issues. The changes made are that the display boundaries have been increased. Additionally I added in a zoom function that allows mouse scroll to zoom in and out - this can also be done using buttons in the display settings tab. The auto scale toggle was introduced so it can be turned off to stop interfering with the scale. It also has been changed so it can zoom all the way out and all the nodes are now visible even over a large scale.