### PR TITLE
Switch to python html5validator in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,11 +32,17 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         
-    - name: 📦 Install Dependencies
-      run: |
-        npm ci
-        npm install -g html5validator stylelint eslint
-        
+    - name: 🐍 Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: 📦 Install Node Dependencies
+      run: npm ci
+
+    - name: 📦 Install Python html5validator
+      run: pip install html5validator
+
     - name: 🌐 HTML Validation
       run: |
         echo "🔍 Validating HTML structure..."

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   ],
   "devDependencies": {
     "live-server": "^1.2.2",
-    "html5-validator": "^1.2.1",
     "gh-pages": "^6.1.1",
     "@playwright/test": "^1.40.0",
     "eslint": "^8.55.0",


### PR DESCRIPTION
This PR updates the CI workflow to use the Python-based html5validator for HTML validation, instead of the (non-existent) npm package. This resolves CI install errors and ensures robust HTML5 validation.