### PR TITLE
Fixing HTML Validator Issues to only validate project files

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,11 +32,17 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         
-    - name: 📦 Install Dependencies
-      run: |
-        npm ci
-        npm install -g html5validator stylelint eslint
-        
+    - name: 🐍 Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: 📦 Install Node Dependencies
+      run: npm ci
+
+    - name: 📦 Install Python html5validator
+      run: pip install html5validator
+
     - name: 🌐 HTML Validation
       run: |
         echo "🔍 Validating HTML structure..."

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,7 +46,7 @@ jobs:
     - name: 🌐 HTML Validation
       run: |
         echo "🔍 Validating HTML structure..."
-        html5validator --root . --match "*.html" --verbose
+        find . -path "./node_modules" -prune -o -name "*.html" -print | xargs html5validator --verbose
         
     - name: 🎨 CSS Linting
       run: |

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   ],
   "devDependencies": {
     "live-server": "^1.2.2",
-    "html5-validator": "^1.2.1",
     "gh-pages": "^6.1.1",
     "@playwright/test": "^1.40.0",
     "eslint": "^8.55.0",


### PR DESCRIPTION
This PR updates the HTML validation step in the GitHub Actions workflow to avoid validating HTML files inside node_modules.

 - The previous command validated all .html files, including those in dependencies, resulting in many irrelevant errors.

 - The new command uses find to exclude node_modules and only validate project HTML files.